### PR TITLE
using libman for getting NPM 6.2.1 package

### DIFF
--- a/California-State-Template-MVC/.gitignore
+++ b/California-State-Template-MVC/.gitignore
@@ -1,0 +1,1 @@
+wwwroot/lib/state-template

--- a/California-State-Template-MVC/Views/Shared/_Layout.cshtml
+++ b/California-State-Template-MVC/Views/Shared/_Layout.cshtml
@@ -11,9 +11,9 @@
         
     Include links to stylesheet and custom theme and core JS.
         
-    <link rel="stylesheet" href="ca_state_template/css/cagov.core.min.css"/>
-    <link rel="stylesheet" href="ca_state_template/css/colortheme-oceanside.min.css"/>
-    <script src="ca_state_template/js/cagov.core.min.js"></script>
+    <link href="~/lib/state-template/dist/css/cagov.core.min.css" rel="stylesheet">
+    <link href="~/lib/state-template/dist/css/colortheme-oceanside.min.css" rel="stylesheet">
+    <script src="~/lib/state-template/dist/js/cagov.core.min.js"></script>
 
     You may also use the CDN instead of using the local folder...
 
@@ -22,9 +22,9 @@
     <script src="https://california.azureedge.net/cdt/statetemplate/6.2.1/js/cagov.core.min.js"></script>
 
     -->
-    <link href="https://california.azureedge.net/cdt/statetemplate/6.2.1/css/cagov.core.min.css" rel="stylesheet">
-    <link href="https://california.azureedge.net/cdt/statetemplate/6.2.1/css/colortheme-oceanside.min.css" rel="stylesheet">
-    <script src="https://california.azureedge.net/cdt/statetemplate/6.2.1/js/cagov.core.min.js"></script>
+    <link href="~/lib/state-template/dist/css/cagov.core.min.css" rel="stylesheet">
+    <link href="~/lib/state-template/dist/css/colortheme-oceanside.min.css" rel="stylesheet">
+    <script src="~/lib/state-template/dist/js/cagov.core.min.js"></script>
     <!-- END STATE_TEMPLATE -->
 
     <link rel="apple-touch-icon-precomposed" sizes="100x100" href="/images/apple-touch-icon-precomposed.png">

--- a/California-State-Template-MVC/libman.json
+++ b/California-State-Template-MVC/libman.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.0",
+  "defaultProvider": "cdnjs",
+  "libraries": [
+    {
+      "provider": "jsdelivr",
+      "library": "@cagovweb/state-template@6.2.1",
+      "destination": "wwwroot/lib/state-template/"
+    }
+  ]
+}


### PR DESCRIPTION
- Adding local installs for NPM to .Net Core via libman
- No longer need NuGet
- A simple way to use code from NPM and run it in your .Net Core project.

more on libman

https://learn.microsoft.com/en-us/aspnet/core/client-side/libman/libman-vs?view=aspnetcore-7.0